### PR TITLE
Fix product name casing of AirPods

### DIFF
--- a/lib/airpodPanel.js
+++ b/lib/airpodPanel.js
@@ -15,7 +15,7 @@ export const AirpodPanel = GObject.registerClass({
     Signals: {'menu-opened': {param_types: [GObject.TYPE_BOOLEAN]}},
 }, class AirpodPanel extends PanelMenu.Button {
     constructor(settings, extensionObj, airpods) {
-        super(0.5, _('Airpod Battery Monitor'));
+        super(0.5, _('AirPods Battery Monitor'));
         this._settings = settings;
         this._extensionObj = extensionObj;
         this._airpods = airpods;

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -2,19 +2,19 @@
 
 export const ModelList = [
     {key: '-1', text: 'Unknown', multipleInfo: false, icon: 'none'},
-    {key: '0220', text: 'Airpods 1st Gen', multipleInfo: true, icon: 'airpod'},
-    {key: '0F20', text: 'Airpods 2nd Gen', multipleInfo: true, icon: 'airpod'},
-    {key: '1320', text: 'Airpods 3rd Gen', multipleInfo: true, icon: 'airpod3'},
-    {key: '0E20', text: 'Airpods Pro', multipleInfo: true, icon: 'airpodpro'},
-    {key: '1420', text: 'Airpods Pro 2nd Gen', multipleInfo: true, icon: 'airpodpro'},
-    {key: '2420', text: 'Airpods Pro 2nd Gen USB-C', multipleInfo: true, icon: 'airpodpro'},
+    {key: '0220', text: 'AirPods 1st Gen', multipleInfo: true, icon: 'airpod'},
+    {key: '0F20', text: 'AirPods 2nd Gen', multipleInfo: true, icon: 'airpod'},
+    {key: '1320', text: 'AirPods 3rd Gen', multipleInfo: true, icon: 'airpod3'},
+    {key: '0E20', text: 'AirPods Pro', multipleInfo: true, icon: 'airpodpro'},
+    {key: '1420', text: 'AirPods Pro 2nd Gen', multipleInfo: true, icon: 'airpodpro'},
+    {key: '2420', text: 'AirPods Pro 2nd Gen USB-C', multipleInfo: true, icon: 'airpodpro'},
     {key: '1220', text: 'Beats Fit Pro ', multipleInfo: true, icon: 'fitpro'},
     {key: '0520', text: 'Beats X', multipleInfo: false, icon: 'flex'},
     {key: '1020', text: 'Beats Flex', multipleInfo: false, icon: 'flex'},
     {key: '0620', text: 'Beats Solo 3', multipleInfo: false, icon: 'solo'},
     {key: '0320', text: 'Powerbeats 3', multipleInfo: false, icon: 'powerbeats'},
     {key: '9', text: 'Beats Studio 3', multipleInfo: false, icon: 'studio'},
-    {key: 'A', text: 'Airpods Max', multipleInfo: false, icon: 'airpodmax'},
+    {key: 'A', text: 'AirPods Max', multipleInfo: false, icon: 'airpodmax'},
     {key: 'B', text: 'Powerbeats Pro', multipleInfo: true, icon: 'powerbeats'},
 ];
 

--- a/po/Airpod-Battery-Monitor.pot
+++ b/po/Airpod-Battery-Monitor.pot
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: lib/airpodPanel.js:18
-msgid "Airpod Battery Monitor"
+msgid "AirPods Battery Monitor"
 msgstr ""
 
 #: lib/airpodPanel.js:26
@@ -106,11 +106,11 @@ msgid "Choose interface style"
 msgstr ""
 
 #: ui/general.ui:28
-msgid "Choose Model of Airpods"
+msgid "Choose Model of AirPods"
 msgstr ""
 
 #: ui/general.ui:31
-msgid "No Airpods paired!"
+msgid "No AirPods paired!"
 msgstr ""
 
 #: ui/general.ui:38

--- a/po/it.po
+++ b/po/it.po
@@ -17,8 +17,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: lib/airpodPanel.js:18
-msgid "Airpod Battery Monitor"
-msgstr "Monitor della batteria dell'Airpod"
+msgid "AirPods Battery Monitor"
+msgstr "Monitor della batteria dell'AirPods"
 
 #: lib/airpodPanel.js:26
 msgid "Headphone Battery Information"
@@ -107,11 +107,11 @@ msgid "Choose interface style"
 msgstr "Scegli lo stile dell'interfaccia"
 
 #: ui/general.ui:28
-msgid "Choose Model of Airpods"
-msgstr "Scegli il modello di Airpods"
+msgid "Choose Model of AirPods"
+msgstr "Scegli il modello di AirPods"
 
 #: ui/general.ui:31
-msgid "No Airpods paired!"
+msgid "No AirPods paired!"
 msgstr "Nessun Airpod abbinato!"
 
 #: ui/general.ui:38

--- a/po/nl.po
+++ b/po/nl.po
@@ -19,8 +19,8 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #: lib/airpodPanel.js:18
-msgid "Airpod Battery Monitor"
-msgstr "Airpod-accumonitor"
+msgid "AirPods Battery Monitor"
+msgstr "AirPods-accumonitor"
 
 #: lib/airpodPanel.js:26
 msgid "Headphone Battery Information"
@@ -109,12 +109,12 @@ msgid "Choose interface style"
 msgstr "Kies een weergavestijl"
 
 #: ui/general.ui:28
-msgid "Choose Model of Airpods"
-msgstr "Kies uw Airpods-uitvoering"
+msgid "Choose Model of AirPods"
+msgstr "Kies uw AirPods-uitvoering"
 
 #: ui/general.ui:31
-msgid "No Airpods paired!"
-msgstr "Er zijn geen Airpods gekoppeld!"
+msgid "No AirPods paired!"
+msgstr "Er zijn geen AirPods gekoppeld!"
 
 #: ui/general.ui:38
 msgid "Meter Indicators with Message tray"

--- a/po/oc.po
+++ b/po/oc.po
@@ -19,8 +19,8 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #: lib/airpodPanel.js:18
-msgid "Airpod Battery Monitor"
-msgstr "Monitor de batariá d’Airpod"
+msgid "AirPods Battery Monitor"
+msgstr "Monitor de batariá d’AirPods"
 
 #: lib/airpodPanel.js:26
 msgid "Headphone Battery Information"
@@ -109,11 +109,11 @@ msgid "Choose interface style"
 msgstr "Causir l’estil de l’interfàcia"
 
 #: ui/general.ui:28
-msgid "Choose Model of Airpods"
+msgid "Choose Model of AirPods"
 msgstr "Causir un modèl d’Airpod"
 
 #: ui/general.ui:31
-msgid "No Airpods paired!"
+msgid "No AirPods paired!"
 msgstr "Cap d’Airpod pas apariat"
 
 #: ui/general.ui:38

--- a/po/ru.po
+++ b/po/ru.po
@@ -19,8 +19,8 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #: lib/airpodPanel.js:18
-msgid "Airpod Battery Monitor"
-msgstr "Монитор батареи Airpods"
+msgid "AirPods Battery Monitor"
+msgstr "Монитор батареи AirPods"
 
 #: lib/airpodPanel.js:26
 msgid "Headphone Battery Information"
@@ -108,12 +108,12 @@ msgid "Choose interface style"
 msgstr "Выберите стиль отображения"
 
 #: ui/general.ui:28
-msgid "Choose Model of Airpods"
+msgid "Choose Model of AirPods"
 msgstr "Выберите модель AirPods"
 
 #: ui/general.ui:31
-msgid "No Airpods paired!"
-msgstr "Нет сопряженных Airpods!"
+msgid "No AirPods paired!"
+msgstr "Нет сопряженных AirPods!"
 
 #: ui/general.ui:38
 msgid "Meter Indicators with Message tray"

--- a/ui/general.ui
+++ b/ui/general.ui
@@ -25,10 +25,10 @@
     
     <child>
       <object class="AdwPreferencesGroup" id="model_group">
-        <property name="title" translatable="yes">Choose Model of Airpods</property>
+        <property name="title" translatable="yes">Choose Model of AirPods</property>
         <child>
           <object class="AdwActionRow" id="no_paired_row">
-            <property name="title" translatable="yes">No Airpods paired!</property>
+            <property name="title" translatable="yes">No AirPods paired!</property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Thanks for developing this extension, it's fantastic! I noticed the word casing of AirPods is displayed as "Airpods" within the extension instead of "AirPods". It's very minor, but it was something I could quickly fix on my side so it matches [Apple's wording of the product.](https://www.apple.com/uk/airpods/).