### PR TITLE
airpodService.js: Added AirPods 4th Gen with ANC to airpodModels

### DIFF
--- a/lib/airpodService.js
+++ b/lib/airpodService.js
@@ -192,7 +192,7 @@ class AirpodService extends GObject.Object {
                 hex += `0${(bytes[j] & 0xFF).toString(16)}`.slice(-2);
 
             // if both pods are charging or powered-off remove them from the list of scanned devices, airpods only
-            const airpodModels = ['0220', '0F20', '1320', '0E20', '1420', '2420', '1220'];
+            const airpodModels = ['0220', '0F20', '1320', '0E20', '1420', '2420', '1220','1B20'];
             if (airpodModels.includes(hex.substring(6, 10))) {
                 const chargeStatus = parseInt(`${hex.charAt(14)}`, 16);
                 const pod1charge = (chargeStatus & 0b00000001) !== 0;


### PR DESCRIPTION
I added AirPods 4th Gen with ANC to airpodModels in airpodService.js in the GNOME43-44 branch. This was included in the GNOME45 PR #28 but not GNOME43-44 PR #27.